### PR TITLE
ci(tests): bump GitHub Actions Go to 1.24

### DIFF
--- a/.github/workflows/testcov.yml
+++ b/.github/workflows/testcov.yml
@@ -15,7 +15,7 @@ jobs:
       - name: set up golang
         uses: actions/setup-go@v6
         with:
-          go-version: 1.23
+          go-version: 1.24
       - name: check out code
         uses: actions/checkout@v5
       - name: unit test


### PR DESCRIPTION
- Align CI tests with go.mod (1.24)
- Unblocks dependabot PRs requiring Go 1.24 (gqlgen/grpc)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go runtime version from 1.23 to 1.24 in the continuous integration pipeline for automated testing and builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->